### PR TITLE
webcam: add a global property of camera number to the open function

### DIFF
--- a/TFLite_detection_webcam.py
+++ b/TFLite_detection_webcam.py
@@ -28,8 +28,9 @@ import importlib.util
 class VideoStream:
     """Camera object that controls video streaming from the Picamera"""
     def __init__(self,resolution=(640,480),framerate=30):
+        camera_num = int(os.environ.get('CAMERA_NUM', 0))
         # Initialize the PiCamera and the camera image stream
-        self.stream = cv2.VideoCapture(0)
+        self.stream = cv2.VideoCapture(camera_num)
         ret = self.stream.set(cv2.CAP_PROP_FOURCC, cv2.VideoWriter_fourcc(*'MJPG'))
         ret = self.stream.set(3,resolution[0])
         ret = self.stream.set(4,resolution[1])


### PR DESCRIPTION
The camera device node is now determined dynamically, as it is not always fixed at /dev/video0. The default value is still 0.

Tested command:
    $ export CAMERA_NUM=3
    $ python3 TFLite_detection_webcam.py --modeldir=./  --edgetpu